### PR TITLE
Support flake8 3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='starscream-flake8',
-    version='0.0.2',
+    version='0.0.3',
 
     install_requires=[
         'setuptools',

--- a/starscream_flake.py
+++ b/starscream_flake.py
@@ -8,7 +8,7 @@ RANGE_LITERAL = re.compile(r'(\srange\()', re.IGNORECASE)
 CLASS_DEFINITION = re.compile(r'\s*class\b')
 METHOD_DEFINITION = re.compile(r'\s*(def|@\w+)\b')
 
-def check_no_json_import(logical_line, physical_line, line_number, filename):
+def check_no_json_import(logical_line, line_number, filename):
     '''
     This function enforces that we are not importing the json default library but the simplejson library.
     '''
@@ -17,7 +17,7 @@ def check_no_json_import(logical_line, physical_line, line_number, filename):
         return match.start(), 'SC01 import json found, use import simplejson instead.'
 
 
-def detect_u_literal(logical_line, physical_line, line_number, filename):
+def detect_u_literal(logical_line, line_number, filename):
     '''
     This function enforces that we are not using u'str' but instead from __future__ import unicode_literals
     '''
@@ -26,7 +26,7 @@ def detect_u_literal(logical_line, physical_line, line_number, filename):
         return match.start(), "SC02 found u'str', please use __future__ import unicode_literals instead."
 
 
-def detect_range_instead_of_xrange(logical_line, physical_line, line_number, filename):
+def detect_range_instead_of_xrange(logical_line, line_number, filename):
     '''
     This function enforces that people are using xrange instead of range as xrange is an iterator which
     is more memory efficient.
@@ -47,20 +47,20 @@ def detect_missing_blank_line_after_class_definition(logical_line, previous_logi
             return method_match.start(), 'E309 expected 1 blank lines between class and method definitions, found 0'
 
 
-def main(logical_line, physical_line, line_number, filename, previous_logical, blank_lines):
+def main(logical_line, line_number, filename, previous_logical, blank_lines):
     results = []
-    if pep8.noqa(physical_line):
+    if pep8.noqa(logical_line):
         return
 
-    result = check_no_json_import(logical_line, physical_line, line_number, filename)
+    result = check_no_json_import(logical_line, line_number, filename)
     if result:
         results.append(result)
 
-    result = detect_u_literal(logical_line, physical_line, line_number, filename)
+    result = detect_u_literal(logical_line, line_number, filename)
     if result:
         results.append(result)
 
-    result = detect_range_instead_of_xrange(logical_line, physical_line, line_number, filename)
+    result = detect_range_instead_of_xrange(logical_line, line_number, filename)
     if result:
         results.append(result)
 
@@ -69,6 +69,7 @@ def main(logical_line, physical_line, line_number, filename, previous_logical, b
         results.append(result)
 
     return results
+
 
 main.name = 'starscream-flake8-plugin'
 main.version = __version__


### PR DESCRIPTION
This has been bugging me for a while.

Flake8 v2 (which we are running in Starscream) is broken in Emacs, and we can't update to v3 until we fix this plugin.

Short story: your plugin can't request both physical and logical line at the same time.

@JasonMWhite @cfournie 